### PR TITLE
fix for #37

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ node_modules
 
 # Ignore built files
 lib
+
+# Ignore mac files
+.DS_Store

--- a/src/index.js
+++ b/src/index.js
@@ -22,9 +22,10 @@ export default class Pivot {
 
   collapse(rowNum) {
     let returnedData = collapse(rowNum, this.data);
+
     if (returnedData.collapsed) {
       this.collapsedRows[this.data.table[rowNum].row] =
-          returnedData.collapsed;
+        returnedData.collapsed;
     }
     this.data = returnedData.uncollapsed;
     return this;

--- a/src/index.js
+++ b/src/index.js
@@ -22,9 +22,10 @@ export default class Pivot {
 
   collapse(rowNum) {
     let returnedData = collapse(rowNum, this.data);
-
-    this.collapsedRows[this.data.table[rowNum].row] =
-        returnedData.collapsed;
+    if (returnedData.collapsed) {
+      this.collapsedRows[this.data.table[rowNum].row] =
+          returnedData.collapsed;
+    }
     this.data = returnedData.uncollapsed;
     return this;
   }


### PR DESCRIPTION
@pat310 I think preferably in the collapse function in progressiveDiscovery.js, collapsed should just not be returned. If the depth of the row being collapsed is the maximum depth (rows.length-1) collapsed should just return. We would have to pass the collapse function row/rows.length in progressiveDiscovery.js, but I think it's fine.

Let me know your thoughts on the issue and the solution options.