### PR TITLE
Progressive filtering modification

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quick-pivot",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "a utility for quickly pivoting data",
   "main": "lib/quick-pivot.min.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,6 @@ export default class Pivot {
     else {
       data = fixDataFormat(data);
       this.originalArgs = {data, rows, cols, agg, type, header};
-      this.filteredArgs = {data, rows, cols, agg, type, header};
       this.originalData = tableCreator(data, rows, cols, agg, type, header);
       this.uniqueValues = createUniqueValues(data);
     }
@@ -53,7 +52,6 @@ export default class Pivot {
     this.originalData = tableCreator(data, rows, cols, agg, type, header);
     this.data = this.originalData;
     this.originalArgs.data = data;
-
     this.collapsedRows = {};
 
     return this;

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ export default class Pivot {
     else {
       data = fixDataFormat(data);
       this.originalArgs = {data, rows, cols, agg, type, header};
+      this.filteredArgs = {data, rows, cols, agg, type, header};
       this.originalData = tableCreator(data, rows, cols, agg, type, header);
       this.uniqueValues = createUniqueValues(data);
     }
@@ -48,8 +49,11 @@ export default class Pivot {
       this.originalArgs = {data, rows, cols, agg, type, header};
       this.uniqueValues = createUniqueValues(data);
     }
+
     this.originalData = tableCreator(data, rows, cols, agg, type, header);
     this.data = this.originalData;
+    this.originalArgs.data = data;
+
     this.collapsedRows = {};
 
     return this;
@@ -144,7 +148,6 @@ export default class Pivot {
         filter(this.originalArgs.data, fieldName, filterValues, filterType);
       /** collect the original arguments provided */
       const {rows, cols, agg, type, header} = this.originalArgs;
-
       /**
        * get the current rows that are collapsed in reverse because we
        * will recollapse them from bottom to top to ensure nested collapses

--- a/src/index.js
+++ b/src/index.js
@@ -146,6 +146,7 @@ export default class Pivot {
         filter(this.originalArgs.data, fieldName, filterValues, filterType);
       /** collect the original arguments provided */
       const {rows, cols, agg, type, header} = this.originalArgs;
+
       /**
        * get the current rows that are collapsed in reverse because we
        * will recollapse them from bottom to top to ensure nested collapses

--- a/test/filtering/filter.js
+++ b/test/filtering/filter.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { filter } from '../../src/filtering.js';
+import Pivot from '../../src';
 
 const data = [
   { name: 'Jon', gender: 'm', house: 'Stark', age: 14 },
@@ -144,4 +145,3 @@ export default () => {
     expect(results).to.deep.equal(data);
   });
 };
-

--- a/test/filtering/filter.js
+++ b/test/filtering/filter.js
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import { filter } from '../../src/filtering.js';
-import Pivot from '../../src';
 
 const data = [
   { name: 'Jon', gender: 'm', house: 'Stark', age: 14 },

--- a/test/index/filter.js
+++ b/test/index/filter.js
@@ -202,7 +202,7 @@ export default () => {
       { value: [ 'sum age', 'sum age' ], depth: 0, type: 'colHeader', row: 0 },
       { value: [ 'Baratheon', 38 ], depth: 0, type: 'rowHeader', row: 1 },
       { value: [ 'f', 38 ], depth: 1, type: 'rowHeader', row: 2 },
-      { value: [ 'Cersei', 38 ], type: 'data', depth: 2, row: 3 }
+      { value: [ 'Cersei', 38 ], type: 'data', depth: 2, row: 3 },
     ];
 
     pivot.filter('house', ['Stark'], 'exclude')
@@ -228,7 +228,7 @@ export default () => {
       { value: [ 'Tyrion', 34 ], type: 'data', depth: 2, row: 10 },
       { value: [ 'Baratheon', 18 ], depth: 0, type: 'rowHeader', row: 11 },
       { value: [ 'm', 18 ], depth: 1, type: 'rowHeader', row: 12 },
-      { value: [ 'Joffrey', 18 ], type: 'data', depth: 2, row: 13 }
+      { value: [ 'Joffrey', 18 ], type: 'data', depth: 2, row: 13 },
     ];
 
     pivot.filter('name', ['Cersei'], 'exclude')
@@ -249,21 +249,21 @@ export default () => {
     );
 
     const expectedResult = [
-        { value: [ 'sum age', 'sum age' ], depth: 0, type: 'colHeader', row: 0 },
-        { value: [ 'Stark', 44 ], depth: 0, type: 'rowHeader', row: 1 },
-        { value: [ 'm', 22 ], depth: 1, type: 'rowHeader', row: 2 },
-        { value: [ 'Jon', 14 ], type: 'data', depth: 2, row: 3 },
-        { value: [ 'Bran', 8 ], type: 'data', depth: 2, row: 4 },
-        { value: [ 'f', 22 ], depth: 1, type: 'rowHeader', row: 5 },
-        { value: [ 'Arya', 10 ], type: 'data', depth: 2, row: 6 },
-        { value: [ 'Sansa', 12 ], type: 'data', depth: 2, row: 7 },
-        { value: [ 'Lannister', 34 ], depth: 0, type: 'rowHeader', row: 8 },
-        { value: [ 'm', 34 ], depth: 1, type: 'rowHeader', row: 9 },
-        { value: [ 'Tyrion', 34 ], type: 'data', depth: 2, row: 10 },
-        { value: [ 'Baratheon', 18 ], depth: 0, type: 'rowHeader', row: 11 },
-        { value: [ 'm', 18 ], depth: 1, type: 'rowHeader', row: 12 },
-        { value: [ 'Joffrey', 18 ], type: 'data', depth: 2, row: 13 }
-      ];
+      { value: [ 'sum age', 'sum age' ], depth: 0, type: 'colHeader', row: 0 },
+      { value: [ 'Stark', 44 ], depth: 0, type: 'rowHeader', row: 1 },
+      { value: [ 'm', 22 ], depth: 1, type: 'rowHeader', row: 2 },
+      { value: [ 'Jon', 14 ], type: 'data', depth: 2, row: 3 },
+      { value: [ 'Bran', 8 ], type: 'data', depth: 2, row: 4 },
+      { value: [ 'f', 22 ], depth: 1, type: 'rowHeader', row: 5 },
+      { value: [ 'Arya', 10 ], type: 'data', depth: 2, row: 6 },
+      { value: [ 'Sansa', 12 ], type: 'data', depth: 2, row: 7 },
+      { value: [ 'Lannister', 34 ], depth: 0, type: 'rowHeader', row: 8 },
+      { value: [ 'm', 34 ], depth: 1, type: 'rowHeader', row: 9 },
+      { value: [ 'Tyrion', 34 ], type: 'data', depth: 2, row: 10 },
+      { value: [ 'Baratheon', 18 ], depth: 0, type: 'rowHeader', row: 11 },
+      { value: [ 'm', 18 ], depth: 1, type: 'rowHeader', row: 12 },
+      { value: [ 'Joffrey', 18 ], type: 'data', depth: 2, row: 13 },
+    ];
 
     pivot.filter('name', ['Cersei'], 'exclude')
          .filter('name', ['Jaime'], 'exclude')

--- a/test/index/filter.js
+++ b/test/index/filter.js
@@ -188,7 +188,8 @@ export default () => {
     expect(pivot.data.table).to.deep.equal(expectedResult);
   });
 
-  it('should progressively filter, when the filter method is called in succession', () => {
+  it('should progressively filter, when the filter method is called in' +
+    'succession', () => {
     const pivot = new Pivot(
       dataArray,
       rowsToPivotTestOne,
@@ -202,13 +203,15 @@ export default () => {
       { value: [ 'Baratheon', 38 ], depth: 0, type: 'rowHeader', row: 1 },
       { value: [ 'f', 38 ], depth: 1, type: 'rowHeader', row: 2 },
       { value: [ 'Cersei', 38 ], type: 'data', depth: 2, row: 3 }
-    ]
+    ];
 
-    pivot.filter('house', ['Stark'], 'exclude').filter('gender', ['m'], 'exclude');
+    pivot.filter('house', ['Stark'], 'exclude')
+         .filter('gender', ['m'], 'exclude');
 
     expect(pivot.data.table).to.deep.equal(expectedResult);
   });
-  it('should progressively filter, when the filter method is called in succession and then collapse', () => {
+  it('should progressively filter, when the filter method is called in' +
+    'succession and then collapse', () => {
     const pivot = new Pivot(
       dataArray,
       rowsToPivotTestOne,
@@ -217,14 +220,16 @@ export default () => {
       aggregationType,
     );
 
-    const expectedResult = [ { value: [ 'sum age', 'sum age' ], depth: 0, type: 'colHeader', row: 0 },
+    const expectedResult = [
+      { value: [ 'sum age', 'sum age' ], depth: 0, type: 'colHeader', row: 0 },
       { value: [ 'Stark', 44 ], depth: 0, type: 'rowHeader', row: 1 },
       { value: [ 'Lannister', 34 ], depth: 0, type: 'rowHeader', row: 8 },
       { value: [ 'm', 34 ], depth: 1, type: 'rowHeader', row: 9 },
       { value: [ 'Tyrion', 34 ], type: 'data', depth: 2, row: 10 },
       { value: [ 'Baratheon', 18 ], depth: 0, type: 'rowHeader', row: 11 },
       { value: [ 'm', 18 ], depth: 1, type: 'rowHeader', row: 12 },
-      { value: [ 'Joffrey', 18 ], type: 'data', depth: 2, row: 13 } ];
+      { value: [ 'Joffrey', 18 ], type: 'data', depth: 2, row: 13 }
+    ];
 
     pivot.filter('name', ['Cersei'], 'exclude')
          .filter('name', ['Jaime'], 'exclude')
@@ -233,7 +238,8 @@ export default () => {
 
     expect(pivot.data.table).to.deep.equal(expectedResult);
   });
-  it('should progressively filter, when the filter method is called in succession and then collapse and then expand', () => {
+  it('should progressively filter, when the filter method is called in' +
+    'succession and then collapse and then expand', () => {
     const pivot = new Pivot(
       dataArray,
       rowsToPivotTestOne,
@@ -242,7 +248,8 @@ export default () => {
       aggregationType,
     );
 
-    const expectedResult = [ { value: [ 'sum age', 'sum age' ],depth: 0,type: 'colHeader',row: 0 },
+    const expectedResult = [
+        { value: [ 'sum age', 'sum age' ], depth: 0, type: 'colHeader', row: 0 },
         { value: [ 'Stark', 44 ], depth: 0, type: 'rowHeader', row: 1 },
         { value: [ 'm', 22 ], depth: 1, type: 'rowHeader', row: 2 },
         { value: [ 'Jon', 14 ], type: 'data', depth: 2, row: 3 },
@@ -250,12 +257,13 @@ export default () => {
         { value: [ 'f', 22 ], depth: 1, type: 'rowHeader', row: 5 },
         { value: [ 'Arya', 10 ], type: 'data', depth: 2, row: 6 },
         { value: [ 'Sansa', 12 ], type: 'data', depth: 2, row: 7 },
-        { value: [ 'Lannister', 34 ],depth: 0,type: 'rowHeader',row: 8 },
+        { value: [ 'Lannister', 34 ], depth: 0, type: 'rowHeader', row: 8 },
         { value: [ 'm', 34 ], depth: 1, type: 'rowHeader', row: 9 },
         { value: [ 'Tyrion', 34 ], type: 'data', depth: 2, row: 10 },
-        { value: [ 'Baratheon', 18 ],depth: 0,type: 'rowHeader',row: 11 },
+        { value: [ 'Baratheon', 18 ], depth: 0, type: 'rowHeader', row: 11 },
         { value: [ 'm', 18 ], depth: 1, type: 'rowHeader', row: 12 },
-        { value: [ 'Joffrey', 18 ], type: 'data', depth: 2, row: 13 } ];
+        { value: [ 'Joffrey', 18 ], type: 'data', depth: 2, row: 13 }
+      ];
 
     pivot.filter('name', ['Cersei'], 'exclude')
          .filter('name', ['Jaime'], 'exclude')

--- a/test/index/filter.js
+++ b/test/index/filter.js
@@ -187,4 +187,25 @@ export default () => {
 
     expect(pivot.data.table).to.deep.equal(expectedResult);
   });
+
+  it('should progressively filter, when the filter method is called in succession', () => {
+    const pivot = new Pivot(
+      dataArray,
+      rowsToPivotTestOne,
+      colsToPivotTestOne,
+      aggregationCategory,
+      aggregationType,
+    );
+
+    const expectedResult = [
+      { value: [ 'sum age', 'sum age' ], depth: 0, type: 'colHeader', row: 0 },
+      { value: [ 'Baratheon', 38 ], depth: 0, type: 'rowHeader', row: 1 },
+      { value: [ 'f', 38 ], depth: 1, type: 'rowHeader', row: 2 },
+      { value: [ 'Cersei', 38 ], type: 'data', depth: 2, row: 3 }
+    ]
+
+    pivot.filter('house', ['Stark'], 'exclude').filter('gender', ['m'], 'exclude');
+
+    expect(pivot.data.table).to.deep.equal(expectedResult);
+  });
 };

--- a/test/index/filter.js
+++ b/test/index/filter.js
@@ -208,4 +208,61 @@ export default () => {
 
     expect(pivot.data.table).to.deep.equal(expectedResult);
   });
+  it('should progressively filter, when the filter method is called in succession and then collapse', () => {
+    const pivot = new Pivot(
+      dataArray,
+      rowsToPivotTestOne,
+      colsToPivotTestOne,
+      aggregationCategory,
+      aggregationType,
+    );
+
+    const expectedResult = [ { value: [ 'sum age', 'sum age' ], depth: 0, type: 'colHeader', row: 0 },
+      { value: [ 'Stark', 44 ], depth: 0, type: 'rowHeader', row: 1 },
+      { value: [ 'Lannister', 34 ], depth: 0, type: 'rowHeader', row: 8 },
+      { value: [ 'm', 34 ], depth: 1, type: 'rowHeader', row: 9 },
+      { value: [ 'Tyrion', 34 ], type: 'data', depth: 2, row: 10 },
+      { value: [ 'Baratheon', 18 ], depth: 0, type: 'rowHeader', row: 11 },
+      { value: [ 'm', 18 ], depth: 1, type: 'rowHeader', row: 12 },
+      { value: [ 'Joffrey', 18 ], type: 'data', depth: 2, row: 13 } ];
+
+    pivot.filter('name', ['Cersei'], 'exclude')
+         .filter('name', ['Jaime'], 'exclude')
+         .collapse(1)
+         .filter('name', ['Tywin'], 'exclude');
+
+    expect(pivot.data.table).to.deep.equal(expectedResult);
+  });
+  it('should progressively filter, when the filter method is called in succession and then collapse and then expand', () => {
+    const pivot = new Pivot(
+      dataArray,
+      rowsToPivotTestOne,
+      colsToPivotTestOne,
+      aggregationCategory,
+      aggregationType,
+    );
+
+    const expectedResult = [ { value: [ 'sum age', 'sum age' ],depth: 0,type: 'colHeader',row: 0 },
+        { value: [ 'Stark', 44 ], depth: 0, type: 'rowHeader', row: 1 },
+        { value: [ 'm', 22 ], depth: 1, type: 'rowHeader', row: 2 },
+        { value: [ 'Jon', 14 ], type: 'data', depth: 2, row: 3 },
+        { value: [ 'Bran', 8 ], type: 'data', depth: 2, row: 4 },
+        { value: [ 'f', 22 ], depth: 1, type: 'rowHeader', row: 5 },
+        { value: [ 'Arya', 10 ], type: 'data', depth: 2, row: 6 },
+        { value: [ 'Sansa', 12 ], type: 'data', depth: 2, row: 7 },
+        { value: [ 'Lannister', 34 ],depth: 0,type: 'rowHeader',row: 8 },
+        { value: [ 'm', 34 ], depth: 1, type: 'rowHeader', row: 9 },
+        { value: [ 'Tyrion', 34 ], type: 'data', depth: 2, row: 10 },
+        { value: [ 'Baratheon', 18 ],depth: 0,type: 'rowHeader',row: 11 },
+        { value: [ 'm', 18 ], depth: 1, type: 'rowHeader', row: 12 },
+        { value: [ 'Joffrey', 18 ], type: 'data', depth: 2, row: 13 } ];
+
+    pivot.filter('name', ['Cersei'], 'exclude')
+         .filter('name', ['Jaime'], 'exclude')
+         .collapse(1)
+         .filter('name', ['Tywin'], 'exclude')
+         .expand(1);
+
+    expect(pivot.data.table).to.deep.equal(expectedResult);
+  });
 };


### PR DESCRIPTION
Upon filtering sets originalArgs.data equal to the filtered data which is then used in successive filter method calls. 

This naming is confusing since originalArgs.data will not always contain the originalArgs and will contain the "filteredArgs" but I don't think we need to add an additional filteredArgs property to the Pivot class. this.originalData is also set equal to the result of the filtered data in the update method so perhaps we should consider renaming originalArgs and originalData. 